### PR TITLE
FKVR-74: Desktop interaction refinements, and more!

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -5,6 +5,8 @@ plugins:
 env:
   es6: true
   browser: true
+globals:
+  AFRAME: true
 parserOptions:
   ecmaVersion: 2015
   ecmaFeatures:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "start": "NODE_ENV=development webpack-dev-server --https",
     "build:dev": "NODE_ENV=development webpack",
     "build:prod": "NODE_ENV=production webpack -p",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post",
+    "precommit": "npm run lint"
   },
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "start": "NODE_ENV=development webpack-dev-server --https",
     "build:dev": "NODE_ENV=development webpack",
     "build:prod": "NODE_ENV=production webpack -p",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post",
-    "precommit": "npm run lint"
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "contributors": [
     {
@@ -54,9 +53,7 @@
     "html-webpack-plugin": "^2.28.0",
     "husky": "^0.13.2",
     "last-release-git": "^0.0.2",
-    "node-sass": "^4.5.0",
     "raw-loader": "^0.5.1",
-    "sass-loader": "^6.0.3",
     "semantic-release": "^6.3.2",
     "style-loader": "^0.14.1",
     "webpack": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -63,11 +63,11 @@
     "webpack-dev-server": "^2.4.2"
   },
   "dependencies": {
-    "aframe": "^0.5.0",
+    "aframe": "^0.6.0",
     "aframe-click-drag-component": "^3.0.1",
     "aframe-look-at-component": "^0.2.0",
-    "aframe-mouse-cursor-component": "^0.4.1",
-    "aframe-react": "^4.0.3",
+    "aframe-mouse-cursor-component": "^0.5.1",
+    "aframe-react": "^4.2.4",
     "aframe-ui-modal-component": "github:patrickocoffeyo/aframe-ui-modal-component",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",

--- a/src/components/Camera.jsx
+++ b/src/components/Camera.jsx
@@ -12,31 +12,40 @@ require('aframe-mouse-cursor-component');
  * Returns React component containing cursor and Camera.
  * {@inheritdoc}
  */
-const Camera = props => (
-  <Entity
-    id="camera"
-    mouse-cursor={!AFRAME.utils.device.checkHeadsetConnected()}
-    camera
-    look-controls {...props}
-  >
-    <a-entity
-      visible={AFRAME.utils.device.checkHeadsetConnected()}
-      cursor="fuseTimeout: 500"
-      position="0 0 -1"
-      geometry="primitive: ring; radiusInner: 0.01; radiusOuter: 0.02"
-      material="color: white; shader: flat"
+const Camera = (props) => {
+  let cursor;
+
+  if (AFRAME.utils.device.checkHeadsetConnected()) {
+    cursor = (
+      <a-entity
+        cursor="fuseTimeout: 500"
+        position="0 0 -1"
+        geometry="primitive: ring; radiusInner: 0.01; radiusOuter: 0.02"
+        material="color: white; shader: flat"
+      >
+        <a-animation
+          begin="click"
+          attribute="material.color"
+          from="white"
+          to="grey"
+          direction="alternate"
+          repeat="1"
+          dur="300"
+        />
+      </a-entity>
+    );
+  }
+
+  return (
+    <Entity
+      id="camera"
+      mouse-cursor={!AFRAME.utils.device.checkHeadsetConnected()}
+      camera
+      look-controls {...props}
     >
-      <a-animation
-        begin="click"
-        attribute="material.color"
-        from="white"
-        to="grey"
-        direction="alternate"
-        repeat="1"
-        dur="300"
-      />
-    </a-entity>
-  </Entity>
-);
+      {cursor}
+    </Entity>
+  );
+};
 
 export default Camera;

--- a/src/components/Camera.jsx
+++ b/src/components/Camera.jsx
@@ -15,11 +15,12 @@ require('aframe-mouse-cursor-component');
 const Camera = props => (
   <Entity
     id="camera"
-    mouse-cursor
+    mouse-cursor={!AFRAME.utils.device.checkHeadsetConnected()}
     camera
     look-controls {...props}
   >
     <a-entity
+      visible={AFRAME.utils.device.checkHeadsetConnected()}
       cursor="fuseTimeout: 500"
       position="0 0 -1"
       geometry="primitive: ring; radiusInner: 0.01; radiusOuter: 0.02"

--- a/src/components/Camera.jsx
+++ b/src/components/Camera.jsx
@@ -14,8 +14,11 @@ require('aframe-mouse-cursor-component');
  */
 const Camera = (props) => {
   let cursor;
+  const gamepads = navigator.getGamepads();
 
-  if (AFRAME.utils.device.checkHeadsetConnected()) {
+  // If this is a mobile device and a headset is not connected, make sure a
+  // fuse-based cursor raycaster appears.
+  if (AFRAME.utils.device.isMobile() && gamepads[0] === null) {
     cursor = (
       <a-entity
         cursor="fuseTimeout: 500"

--- a/src/components/Camera.jsx
+++ b/src/components/Camera.jsx
@@ -4,7 +4,7 @@
  */
 
 import { Entity } from 'aframe-react';
-import React from 'react';
+import React, { Component } from 'react';
 
 require('aframe-mouse-cursor-component');
 
@@ -12,43 +12,64 @@ require('aframe-mouse-cursor-component');
  * Returns React component containing cursor and Camera.
  * {@inheritdoc}
  */
-const Camera = (props) => {
-  let cursor;
-  const gamepads = navigator.getGamepads();
-
-  // If this is a mobile device and a headset is not connected, make sure a
-  // fuse-based cursor raycaster appears.
-  if (AFRAME.utils.device.isMobile() && gamepads[0] === null) {
-    cursor = (
-      <a-entity
-        cursor="fuseTimeout: 500"
-        position="0 0 -1"
-        geometry="primitive: ring; radiusInner: 0.01; radiusOuter: 0.02"
-        material="color: white; shader: flat"
-      >
-        <a-animation
-          begin="click"
-          attribute="material.color"
-          from="white"
-          to="grey"
-          direction="alternate"
-          repeat="1"
-          dur="300"
-        />
-      </a-entity>
-    );
+class Camera extends Component {
+  /**
+   * {@inheretDoc}
+   */
+  constructor(props) {
+    super(props);
+    this.state = {
+      gamepad: null,
+    };
   }
 
-  return (
-    <Entity
-      id="camera"
-      mouse-cursor={!AFRAME.utils.device.checkHeadsetConnected()}
-      camera
-      look-controls {...props}
-    >
-      {cursor}
-    </Entity>
-  );
-};
+  componentDidMount() {
+    window.addEventListener('gamepadconnected', (e) => {
+      this.setState({ gamepad: e.gamepad.id });
+    });
+
+    window.addEventListener('gamepaddisconnected', () => {
+      this.setState({ gamepad: null });
+    });
+  }
+
+  render() {
+    let cursor;
+
+    // If this is a mobile device and a headset is not connected, make sure a
+    // fuse-based cursor raycaster appears.
+    if (AFRAME.utils.device.isMobile() && this.state.gamepad === null) {
+      cursor = (
+        <a-entity
+          cursor="fuseTimeout: 500"
+          position="0 0 -1"
+          geometry="primitive: ring; radiusInner: 0.01; radiusOuter: 0.02"
+          material="color: white; shader: flat"
+        >
+          <a-animation
+            begin="click"
+            attribute="material.color"
+            from="white"
+            to="grey"
+            direction="alternate"
+            repeat="1"
+            dur="300"
+          />
+        </a-entity>
+      );
+    }
+
+    return (
+      <Entity
+        id="camera"
+        mouse-cursor={!AFRAME.utils.device.checkHeadsetConnected()}
+        camera
+        look-controls {...this.state.props}
+      >
+        {cursor}
+      </Entity>
+    );
+  }
+}
 
 export default Camera;

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -43,8 +43,7 @@ class Modal extends React.Component {
       if (e.constructor.name === 'CustomEvent') {
         if (e.target.id === `${this.props.id}-hotspot`) {
           this.toggleVisibility(true);
-        }
-        else {
+        } else {
           this.setState({ visible: false });
         }
       }
@@ -54,18 +53,17 @@ class Modal extends React.Component {
   /**
    * Toggles the visibility of the modal attached to the hot spot.
    *
-   * @param {string} visible Optional boolean indicating whether or not this
-   *                         modal should be set to visible.
+   * @param {string} visibility
+   *   Optional boolean indicating whether or not this should be visible.
    */
-  toggleVisibility(visible) {
+  toggleVisibility(visibility) {
+    let visible = visibility;
     if (typeof visible === 'undefined') {
       visible = !this.state.visible;
     }
 
     // Update the state visibility property.
-    this.setState({
-      visible: visible,
-    });
+    this.setState({ visible });
 
     // Track event in Google Analytics.
     const action = visible ? 'closed' : 'opened';

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -46,7 +46,7 @@ class Modal extends React.Component {
       if (e.constructor.name === 'CustomEvent' && e.target.id === `${this.props.id}-hotspot`) {
         this.toggleVisibility(true);
       } else if ((Date.now() - this.state.lastActivation) > 100 &&
-                 (!AFRAME.utils.device.isMobile() || AFRAME.utils.device.checkHeadsetConnected())) {
+                 (!AFRAME.utils.device.isMobile())) {
         this.toggleVisibility(false);
       }
     });

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -37,10 +37,16 @@ class Modal extends React.Component {
   }
 
   componentDidMount() {
+    // Listen for all clicks.
     document.addEventListener('click', (e) => {
+      // If this is a custom event, and a click this modal's hotspot, open.
+      // Otherwise, if the last activation timestamp is over 100 ms ago (not a
+      // rouge event), and the current device isn't a cardboard with a fuse
+      // based cursor, this is a close event.
       if (e.constructor.name === 'CustomEvent' && e.target.id === `${this.props.id}-hotspot`) {
         this.toggleVisibility(true);
-      } else if ((Date.now() - this.state.lastActivation) > 100) {
+      } else if ((Date.now() - this.state.lastActivation) > 100 &&
+                 (!AFRAME.utils.device.isMobile() || AFRAME.utils.device.checkHeadsetConnected())) {
         this.toggleVisibility(false);
       }
     });

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -26,6 +26,7 @@ class Modal extends React.Component {
       height: 2.5,
       width: 4,
       textOffset: -1.5,
+      lastActivation: null,
     };
 
     // Adjust modal height and text offset if a modal image was provided.
@@ -35,17 +36,12 @@ class Modal extends React.Component {
     }
   }
 
-  /**
-   * Sets up event listeners and dispatchers for modal-open events.
-   */
   componentDidMount() {
     document.addEventListener('click', (e) => {
-      if (e.constructor.name === 'CustomEvent') {
-        if (e.target.id === `${this.props.id}-hotspot`) {
-          this.toggleVisibility(true);
-        } else {
-          this.setState({ visible: false });
-        }
+      if (e.constructor.name === 'CustomEvent' && e.target.id === `${this.props.id}-hotspot`) {
+        this.toggleVisibility(true);
+      } else if ((Date.now() - this.state.lastActivation) > 100) {
+        this.toggleVisibility(false);
       }
     });
   }
@@ -63,7 +59,7 @@ class Modal extends React.Component {
     }
 
     // Update the state visibility property.
-    this.setState({ visible });
+    this.setState({ visible, lastActivation: Date.now() });
 
     // Track event in Google Analytics.
     const action = visible ? 'closed' : 'opened';

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -166,7 +166,7 @@ class Modal extends React.Component {
             src={require('../assets/images/jpg/x.jpg')}
             position={this.props.image.length > 0 ? '-0.9 0.5 0.5' : '0 0.7 0.5'}
             radius="0.3"
-            onClick={() => this.toggleVisibility()}
+            onClick={() => this.toggleVisibility(false)}
           />
         </Entity>
       </Entity>

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -39,28 +39,36 @@ class Modal extends React.Component {
    * Sets up event listeners and dispatchers for modal-open events.
    */
   componentDidMount() {
-    document.addEventListener('modal-opened', (e) => {
-      // If the modal being "opened" is not the current modal, close.
-      if (e.detail !== this.props.id) {
-        this.setState({ visible: false });
+    document.addEventListener('click', (e) => {
+      if (e.constructor.name === 'CustomEvent') {
+        if (e.target.id === `${this.props.id}-hotspot`) {
+          this.toggleVisibility(true);
+        }
+        else {
+          this.setState({ visible: false });
+        }
       }
     });
   }
 
   /**
    * Toggles the visibility of the modal attached to the hot spot.
+   *
+   * @param {string} visible Optional boolean indicating whether or not this
+   *                         modal should be set to visible.
    */
-  toggleVisibility() {
-    // Dispatch an an event.
-    const action = this.state.visible ? 'closed' : 'opened';
-    document.dispatchEvent(new CustomEvent(`modal-${action}`, { detail: this.props.id }));
+  toggleVisibility(visible) {
+    if (typeof visible === 'undefined') {
+      visible = !this.state.visible;
+    }
 
     // Update the state visibility property.
     this.setState({
-      visible: !this.state.visible,
+      visible: visible,
     });
 
     // Track event in Google Analytics.
+    const action = visible ? 'closed' : 'opened';
     ReactGA.event({
       category: 'Hotspot',
       action: `${action} Modal`,
@@ -110,7 +118,6 @@ class Modal extends React.Component {
           color="#FFFFFF"
           position={`${this.props.position.x} ${this.props.position.y} ${this.props.position.z}`}
           look-at="#camera"
-          onClick={() => this.toggleVisibility()}
         />
         <Entity
           id={`${this.props.id}-box`}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -118,10 +118,10 @@ class NavigationScene extends React.Component {
   render() {
     return (
       <Scene inspector="url: https://aframe.io/releases/0.3.0/aframe-inspector.min.js">
+        <Entity laser-controls position={{ x: 0.3, y: -0.6, z: 0 }} />
         <Entity primative="a-assets">{this.fetchSkys()}</Entity>
-        <Entity primitive="a-sky" radius="30" src={`#${this.state.currentScene.name}`} />
+        <Entity onClick={console.log('yay')} primitive="a-sky" radius="30" src={`#${this.state.currentScene.name}`} />
         <Camera />
-
         {this.state.currentScene.scene()}
       </Scene>
     );

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -120,7 +120,7 @@ class NavigationScene extends React.Component {
       <Scene inspector="url: https://aframe.io/releases/0.3.0/aframe-inspector.min.js">
         <Entity laser-controls position={{ x: 0.3, y: -0.6, z: 0 }} />
         <Entity primative="a-assets">{this.fetchSkys()}</Entity>
-        <Entity onClick={console.log('yay')} primitive="a-sky" radius="30" src={`#${this.state.currentScene.name}`} />
+        <Entity primitive="a-sky" radius="30" src={`#${this.state.currentScene.name}`} />
         <Camera />
         {this.state.currentScene.scene()}
       </Scene>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -17,8 +17,6 @@ import SuzyOffice from './components/scenes/Suzy-office.jsx';
 import MikeOffice from './components/scenes/Mike-office.jsx';
 import MikeWorkshop from './components/scenes/Mike-workshop.jsx';
 
-require('./styles/index.scss');
-
 registerClickDrag(aframe);
 ReactGA.initialize('UA-559851-16');
 

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,9 +1,0 @@
-/**
- * @file index.scss
- * Sass file that defines styles for the main scene.
- */
-
-.application-container {
-  width: 100%;
-  height: 100%;
-}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,7 +57,6 @@ const fetchIp = () => (
     if (DEVELOPMENT_SERVER_IP) {
       resolve(DEVELOPMENT_SERVER_IP);
     } else {
-      dns.lookup(os.hostname(), (e, a) => console.log(a));
       dns.lookup(os.hostname(), (error, address) => (error ? reject(error) : resolve(address)));
     }
   })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,10 +44,6 @@ const loaders = [
     test: /\.(dae)$/i,
     loaders: ['file-loader'],
   },
-  {
-    test: /\.scss$/,
-    loaders: ['style-loader', 'css-loader', 'sass-loader'],
-  },
 ];
 
 /**
@@ -61,6 +57,7 @@ const fetchIp = () => (
     if (DEVELOPMENT_SERVER_IP) {
       resolve(DEVELOPMENT_SERVER_IP);
     } else {
+      dns.lookup(os.hostname(), (e, a) => console.log(a));
       dns.lookup(os.hostname(), (error, address) => (error ? reject(error) : resolve(address)));
     }
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1731,19 +1731,19 @@ debug@0.7.4:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-0.7.4.tgz#06e1ea8082c2cb14e39806e22e2f6f757f92af39"
 
-debug@2, debug@2.6.3, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.3.tgz#0f7eb8c30965ec08c72accfa0130c8b79984141d"
+debug@2, debug@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
   dependencies:
     ms "0.7.2"
 
-debug@2.2.0, debug@ngokevin/debug#noTimestamp, debug@~2.2.0:
+debug@2.2.0, debug@^2.1.1, debug@^2.2.0, debug@ngokevin/debug#noTimestamp, debug@~2.2.0:
   version "2.2.0"
   resolved "https://codeload.github.com/ngokevin/debug/tar.gz/ef5f8e66d49ce8bc64c6f282c15f8b7164409e3a"
 
-debug@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
+debug@2.6.3, debug@^2.1.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.3.tgz#0f7eb8c30965ec08c72accfa0130c8b79984141d"
   dependencies:
     ms "0.7.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,24 +80,24 @@ aframe-look-at-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/aframe-look-at-component/-/aframe-look-at-component-0.2.0.tgz#070c82b137fb9253d2be0e4cb8d2638a6ce99dd9"
 
-aframe-mouse-cursor-component@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/aframe-mouse-cursor-component/-/aframe-mouse-cursor-component-0.4.1.tgz#f3784416fc3b7c65551064145846625af8ca3243"
+aframe-mouse-cursor-component@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/aframe-mouse-cursor-component/-/aframe-mouse-cursor-component-0.5.1.tgz#537d4d84c05471b8afeed84ff5db1ef7cbd22f19"
 
-aframe-react@^4.0.3:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/aframe-react/-/aframe-react-4.0.7.tgz#7258317f22430515410eb0144c80190a8dc097a4"
+aframe-react@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/aframe-react/-/aframe-react-4.2.4.tgz#3a69cb2dda6f0c517478a37884d71990053fd28f"
 
 "aframe-ui-modal-component@github:patrickocoffeyo/aframe-ui-modal-component":
   version "1.0.0"
   resolved "https://codeload.github.com/patrickocoffeyo/aframe-ui-modal-component/tar.gz/b3fd81793c042f1a60870ed43060f798115fa87d"
 
-aframe@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/aframe/-/aframe-0.5.0.tgz#c6335cad86ee7a731062415b718da79e764e96ef"
+aframe@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/aframe/-/aframe-0.6.0.tgz#b15ccbb81ab7649ba43c63530e150c3c5fc124ee"
   dependencies:
     browserify-css "^0.8.2"
-    debug "^2.2.0"
+    debug ngokevin/debug#noTimestamp
     deep-assign "^2.0.0"
     document-register-element dmarcos/document-register-element#8ccc532b7
     envify "^3.4.1"
@@ -106,10 +106,10 @@ aframe@^0.5.0:
     present "0.0.6"
     promise-polyfill "^3.1.0"
     style-attr "^1.0.2"
-    three "^0.83.0"
+    three "^0.84.0"
     three-bmfont-text "^2.1.0"
     tween.js "^15.0.0"
-    webvr-polyfill dmarcos/webvr-polyfill#a02a8089b
+    webvr-polyfill "^0.9.35"
 
 agent-base@2:
   version "2.0.1"
@@ -1758,11 +1758,9 @@ debug@2, debug@2.6.3, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0:
   dependencies:
     ms "0.7.2"
 
-debug@2.2.0, debug@~2.2.0:
+debug@2.2.0, debug@ngokevin/debug#noTimestamp, debug@~2.2.0:
   version "2.2.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
-  dependencies:
-    ms "0.7.1"
+  resolved "https://codeload.github.com/ngokevin/debug/tar.gz/ef5f8e66d49ce8bc64c6f282c15f8b7164409e3a"
 
 debug@2.6.1:
   version "2.6.1"
@@ -2359,10 +2357,6 @@ event-stream@^3.3.0:
 eventemitter3@1.x.x:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.2.0.tgz#1c86991d816ad1e504750e73874224ecf3bec508"
-
-eventemitter3@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-2.0.3.tgz#b5e1079b59fb5e1ba2771c0a993be060a58c99ba"
 
 events-to-array@^1.0.1:
   version "1.0.2"
@@ -4518,10 +4512,6 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkd
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
-
-ms@0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
 
 ms@0.7.2:
   version "0.7.2"
@@ -6751,9 +6741,9 @@ three-buffer-vertex-data@^1.0.0:
   dependencies:
     flatten-vertex-data "^1.0.0"
 
-three@^0.83.0:
-  version "0.83.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.83.0.tgz#3b7f94790af3e021dac1f44a2617569ca2032b0b"
+three@^0.84.0:
+  version "0.84.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.84.0.tgz#95be85a55a0fa002aa625ed559130957dcffd918"
 
 throttleit@^1.0.0:
   version "1.0.0"
@@ -7295,12 +7285,9 @@ websocket-extensions@>=0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.1.tgz#76899499c184b6ef754377c2dbb0cd6cb55d29e7"
 
-webvr-polyfill@dmarcos/webvr-polyfill#a02a8089b:
-  version "0.9.25"
-  resolved "https://codeload.github.com/dmarcos/webvr-polyfill/tar.gz/a02a8089b"
-  dependencies:
-    eventemitter3 "^2.0.2"
-    object-assign "^4.0.1"
+webvr-polyfill@^0.9.35:
+  version "0.9.35"
+  resolved "https://registry.yarnpkg.com/webvr-polyfill/-/webvr-polyfill-0.9.35.tgz#5740d7ef41f01234c051ce5298d18b87a532102f"
 
 whatwg-fetch@>=0.10.0:
   version "2.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -319,10 +319,6 @@ async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
 
-async-foreach@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/async-foreach/-/async-foreach-0.1.3.tgz#36121f845c0578172de419a97dbeb1d16ec34542"
-
 async@^0.9.0:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
@@ -331,7 +327,7 @@ async@^1.3.0, async@^1.4.0, async@^1.5.0, async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^2.0.1, async@^2.1.2, async@^2.1.5:
+async@^2.0.1, async@^2.1.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/async/-/async-2.2.0.tgz#c324eba010a237e4fbd55a12dee86367d5c0ef32"
   dependencies:
@@ -1247,16 +1243,6 @@ clone-buffer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/clone-buffer/-/clone-buffer-1.0.0.tgz#e3e25b207ac4e701af721e2cb5a16792cac3dc58"
 
-clone-deep@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-0.2.4.tgz#4e73dd09e9fb971cc38670c5dced9c1896481cc6"
-  dependencies:
-    for-own "^0.1.3"
-    is-plain-object "^2.0.1"
-    kind-of "^3.0.2"
-    lazy-cache "^1.0.3"
-    shallow-clone "^0.1.2"
-
 clone-stats@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/clone-stats/-/clone-stats-0.0.1.tgz#b88f94a82cf38b8791d58046ea4029ad88ca99d1"
@@ -1542,13 +1528,6 @@ create-react-class@^15.5.2:
 cross-spawn@4.0.0, cross-spawn@^4:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.0.tgz#8254774ab4786b8c5b3cf4dfba66ce563932c252"
-  dependencies:
-    lru-cache "^4.0.1"
-    which "^1.2.9"
-
-cross-spawn@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-3.0.1.tgz#1256037ecb9f0c5f79e3d6ef135e30770184b982"
   dependencies:
     lru-cache "^4.0.1"
     which "^1.2.9"
@@ -2684,15 +2663,11 @@ for-each@^0.3.2:
   dependencies:
     is-function "~1.0.0"
 
-for-in@^0.1.3:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.8.tgz#d8773908e31256109952b1fdb9b3fa867d2775e1"
-
 for-in@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
 
-for-own@^0.1.3, for-own@^0.1.4:
+for-own@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce"
   dependencies:
@@ -2818,12 +2793,6 @@ gaze@^0.5.1:
   dependencies:
     globule "~0.1.0"
 
-gaze@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/gaze/-/gaze-1.1.2.tgz#847224677adb8870d679257ed3388fdb61e40105"
-  dependencies:
-    globule "^1.0.0"
-
 generate-function@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-2.0.0.tgz#6858fe7c0969b7d4e9093337647ac79f60dfbe74"
@@ -2945,7 +2914,7 @@ glob@^5.0.15:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@~7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -3008,14 +2977,6 @@ globby@^5.0.0:
     object-assign "^4.0.1"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
-
-globule@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/globule/-/globule-1.1.0.tgz#c49352e4dc183d85893ee825385eb994bb6df45f"
-  dependencies:
-    glob "~7.1.1"
-    lodash "~4.16.4"
-    minimatch "~3.0.2"
 
 globule@~0.1.0:
   version "0.1.0"
@@ -3425,10 +3386,6 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
-in-publish@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/in-publish/-/in-publish-2.0.0.tgz#e20ff5e3a2afc2690320b6dc552682a9c7fadf51"
-
 indent-string@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
@@ -3648,12 +3605,6 @@ is-plain-obj@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
 
-is-plain-object@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.1.tgz#4d7ca539bc9db9b737b8acb612f2318ef92f294f"
-  dependencies:
-    isobject "^1.0.0"
-
 is-posix-bracket@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
@@ -3731,10 +3682,6 @@ isexe@^1.0.0:
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
-
-isobject@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/isobject/-/isobject-1.0.2.tgz#f0f9b8ce92dd540fa0740882e3835a2e022ec78a"
 
 isobject@^2.0.0:
   version "2.1.0"
@@ -3960,12 +3907,6 @@ kew@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/kew/-/kew-0.7.0.tgz#79d93d2d33363d6fdd2970b335d9141ad591d79b"
 
-kind-of@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-2.0.1.tgz#018ec7a4ce7e3a86cb9141be519d24c8faa981b5"
-  dependencies:
-    is-buffer "^1.0.2"
-
 kind-of@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.1.0.tgz#475d698a5e49ff5e53d14e3e732429dc8bf4cf47"
@@ -3991,10 +3932,6 @@ layout-bmfont-text@^1.2.0:
     as-number "^1.0.0"
     word-wrapper "^1.0.7"
     xtend "^4.0.0"
-
-lazy-cache@^0.2.3:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-0.2.7.tgz#7feddf2dcb6edb77d11ef1d117ab5ffdf0ab1b65"
 
 lazy-cache@^1.0.3:
   version "1.0.4"
@@ -4066,7 +4003,7 @@ loader-utils@^0.2.11, loader-utils@^0.2.14, loader-utils@^0.2.16:
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
-loader-utils@^1.0.1, loader-utils@^1.0.2:
+loader-utils@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
   dependencies:
@@ -4137,7 +4074,7 @@ lodash.assign@^3.0.0:
     lodash._createassigner "^3.0.0"
     lodash.keys "^3.0.0"
 
-lodash.assign@^4.0.3, lodash.assign@^4.0.6, lodash.assign@^4.0.9, lodash.assign@^4.2.0:
+lodash.assign@^4.0.3, lodash.assign@^4.0.6, lodash.assign@^4.0.9:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
 
@@ -4199,10 +4136,6 @@ lodash.memoize@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
 
-lodash.mergewith@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz#150cf0a16791f5903b8891eab154609274bdea55"
-
 lodash.pad@^4.1.0:
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/lodash.pad/-/lodash.pad-4.5.1.tgz#4330949a833a7c8da22cc20f6a26c4d59debba70"
@@ -4222,10 +4155,6 @@ lodash.pick@^4.2.1:
 lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-
-lodash.tail@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.tail/-/lodash.tail-4.1.1.tgz#d2333a36d9e7717c8ad2f7cacafec7c32b444664"
 
 lodash.template@^3.0.0:
   version "3.6.2"
@@ -4275,10 +4204,6 @@ lodash@~1.3.1:
 lodash@~2.4.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-2.4.2.tgz#fadd834b9683073da179b3eae6d9c0d15053f73e"
-
-lodash@~4.16.4:
-  version "4.16.6"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.16.6.tgz#d22c9ac660288f3843e16ba7d2b5d06cca27d777"
 
 log-driver@1.2.5:
   version "1.2.5"
@@ -4374,7 +4299,7 @@ memory-fs@~0.3.0:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
-meow@^3.3.0, meow@^3.7.0:
+meow@^3.3.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
   dependencies:
@@ -4494,13 +4419,6 @@ minimist@1.2.0, minimist@^1.1.0, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
-mixin-object@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/mixin-object/-/mixin-object-2.0.1.tgz#4fb949441dab182540f1fe035ba60e1947a5e57e"
-  dependencies:
-    for-in "^0.1.3"
-    is-extendable "^0.1.1"
-
 mkdirp@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.0.tgz#1d73076a6df986cd9344e15e71fcc05a4c9abf12"
@@ -4527,7 +4445,7 @@ mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
 
-nan@^2.3.0, nan@^2.3.2:
+nan@^2.3.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.5.1.tgz#d5b01691253326a97a2bbee9e61c55d8d60351e2"
 
@@ -4582,24 +4500,6 @@ node-fetch@^1.0.1:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
-
-node-gyp@^3.3.1:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.6.0.tgz#7474f63a3a0501161dda0b6341f022f14c423fa6"
-  dependencies:
-    fstream "^1.0.0"
-    glob "^7.0.3"
-    graceful-fs "^4.1.2"
-    minimatch "^3.0.2"
-    mkdirp "^0.5.0"
-    nopt "2 || 3"
-    npmlog "0 || 1 || 2 || 3 || 4"
-    osenv "0"
-    request "2"
-    rimraf "2"
-    semver "~5.3.0"
-    tar "^2.0.0"
-    which "1"
 
 node-libs-browser@^0.7.0:
   version "0.7.0"
@@ -4678,29 +4578,6 @@ node-rest-client@^1.5.1:
     debug "~2.2.0"
     xml2js ">=0.2.4"
 
-node-sass@^4.5.0:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.5.2.tgz#4012fa2bd129b1d6365117e88d9da0500d99da64"
-  dependencies:
-    async-foreach "^0.1.3"
-    chalk "^1.1.1"
-    cross-spawn "^3.0.0"
-    gaze "^1.0.0"
-    get-stdin "^4.0.1"
-    glob "^7.0.3"
-    in-publish "^2.0.0"
-    lodash.assign "^4.2.0"
-    lodash.clonedeep "^4.3.2"
-    lodash.mergewith "^4.6.0"
-    meow "^3.7.0"
-    mkdirp "^0.5.1"
-    nan "^2.3.2"
-    node-gyp "^3.3.1"
-    npmlog "^4.0.0"
-    request "^2.79.0"
-    sass-graph "^2.1.1"
-    stdout-stream "^1.4.0"
-
 node-uuid@~1.4.7:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907"
@@ -4711,18 +4588,18 @@ nodeunit@^0.9.0:
   dependencies:
     tap "^7.0.0"
 
-"nopt@2 || 3", nopt@~3.0.1:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
-  dependencies:
-    abbrev "1"
-
 nopt@^4.0.0, nopt@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
   dependencies:
     abbrev "1"
     osenv "^0.1.4"
+
+nopt@~3.0.1:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
+  dependencies:
+    abbrev "1"
 
 normalize-package-data@^1.0.3:
   version "1.0.3"
@@ -4801,7 +4678,7 @@ npmconf@^2.1.2:
     semver "2 || 3 || 4"
     uid-number "0.0.5"
 
-"npmlog@0 || 1 || 2 || 3 || 4", "npmlog@2 || ^3.1.0 || ^4.0.0", npmlog@^4.0.0, npmlog@^4.0.2:
+"npmlog@2 || ^3.1.0 || ^4.0.0", npmlog@^4.0.0, npmlog@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.0.2.tgz#d03950e0e78ce1527ba26d2a7592e9348ac3e75f"
   dependencies:
@@ -5010,7 +4887,7 @@ os-tmpdir@^1.0.0, os-tmpdir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
-osenv@0, osenv@^0.1.0, osenv@^0.1.4:
+osenv@^0.1.0, osenv@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.4.tgz#42fe6d5953df06c8064be6f176c3d05aaaa34644"
   dependencies:
@@ -5189,7 +5066,7 @@ phantomjs-prebuilt@^2.1.10:
     request-progress "~2.0.1"
     which "~1.2.10"
 
-pify@^2.0.0, pify@^2.3.0:
+pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
 
@@ -5923,7 +5800,32 @@ request-promise@^4.1.1:
     request-promise-core "1.1.1"
     stealthy-require "^1.0.0"
 
-request@2, request@^2.65.0, request@^2.74.0, request@^2.78.0, request@^2.79.0, request@^2.81.0:
+request@2.79.0, request@~2.79.0:
+  version "2.79.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
+  dependencies:
+    aws-sign2 "~0.6.0"
+    aws4 "^1.2.1"
+    caseless "~0.11.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.0"
+    forever-agent "~0.6.1"
+    form-data "~2.1.1"
+    har-validator "~2.0.6"
+    hawk "~3.1.3"
+    http-signature "~1.1.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.7"
+    oauth-sign "~0.8.1"
+    qs "~6.3.0"
+    stringstream "~0.0.4"
+    tough-cookie "~2.3.0"
+    tunnel-agent "~0.4.1"
+    uuid "^3.0.0"
+
+request@^2.65.0, request@^2.74.0, request@^2.78.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -5948,31 +5850,6 @@ request@2, request@^2.65.0, request@^2.74.0, request@^2.78.0, request@^2.79.0, r
     stringstream "~0.0.4"
     tough-cookie "~2.3.0"
     tunnel-agent "^0.6.0"
-    uuid "^3.0.0"
-
-request@2.79.0, request@~2.79.0:
-  version "2.79.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
-  dependencies:
-    aws-sign2 "~0.6.0"
-    aws4 "^1.2.1"
-    caseless "~0.11.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.0"
-    forever-agent "~0.6.1"
-    form-data "~2.1.1"
-    har-validator "~2.0.6"
-    hawk "~3.1.3"
-    http-signature "~1.1.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.7"
-    oauth-sign "~0.8.1"
-    qs "~6.3.0"
-    stringstream "~0.0.4"
-    tough-cookie "~2.3.0"
-    tunnel-agent "~0.4.1"
     uuid "^3.0.0"
 
 request@~2.74.0:
@@ -6123,24 +6000,6 @@ safe-env@1.2.0:
   dependencies:
     ramda "0.22.1"
 
-sass-graph@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/sass-graph/-/sass-graph-2.1.2.tgz#965104be23e8103cb7e5f710df65935b317da57b"
-  dependencies:
-    glob "^7.0.0"
-    lodash "^4.0.0"
-    yargs "^4.7.1"
-
-sass-loader@^6.0.3:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-6.0.3.tgz#33983b1f90d27ddab0e57d0dac403dce9bc7ecfd"
-  dependencies:
-    async "^2.1.5"
-    clone-deep "^0.2.4"
-    loader-utils "^1.0.1"
-    lodash.tail "^4.1.1"
-    pify "^2.3.0"
-
 sax@>=0.6.0, sax@~1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.2.tgz#fd8631a23bc7826bef5d871bdb87378c95647828"
@@ -6172,7 +6031,7 @@ semantic-release@^6.3.2:
     run-series "^1.1.3"
     semver "^5.2.0"
 
-"semver@2 >=2.2.1 || 3.x || 4 || 5", "semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.2.0, semver@^5.3.0, semver@~5.3.0:
+"semver@2 >=2.2.1 || 3.x || 4 || 5", "semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.2.0, semver@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
@@ -6256,15 +6115,6 @@ sha.js@^2.3.6:
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.8.tgz#37068c2c476b6baf402d14a49c67f597921f634f"
   dependencies:
     inherits "^2.0.1"
-
-shallow-clone@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-0.1.2.tgz#5909e874ba77106d73ac414cfec1ffca87d97060"
-  dependencies:
-    is-extendable "^0.1.1"
-    kind-of "^2.0.1"
-    lazy-cache "^0.2.3"
-    mixin-object "^2.0.1"
 
 shelljs@0.3.x:
   version "0.3.0"
@@ -6451,12 +6301,6 @@ stack-utils@^0.4.0:
 "statuses@>= 1.3.1 < 2", statuses@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
-
-stdout-stream@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/stdout-stream/-/stdout-stream-1.4.0.tgz#a2c7c8587e54d9427ea9edb3ac3f2cd522df378b"
-  dependencies:
-    readable-stream "^2.0.1"
 
 stealthy-require@^1.0.0:
   version "1.0.0"
@@ -6701,7 +6545,7 @@ tar-pack@^3.4.0:
     tar "^2.2.1"
     uid-number "^0.0.6"
 
-tar@^2.0.0, tar@^2.2.1:
+tar@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
   dependencies:
@@ -7301,7 +7145,7 @@ which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
 
-which@1, which@^1.2.12, which@^1.2.4, which@^1.2.9, which@~1.2.10:
+which@^1.2.12, which@^1.2.4, which@^1.2.9, which@~1.2.10:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
   dependencies:
@@ -7445,7 +7289,7 @@ yargs@^3.31.0:
     window-size "^0.1.4"
     y18n "^3.2.0"
 
-yargs@^4.7.1, yargs@^4.8.1:
+yargs@^4.8.1:
   version "4.8.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-4.8.1.tgz#c0c42924ca4aaa6b0e6da1739dfb216439f9ddc0"
   dependencies:


### PR DESCRIPTION
# [FKVR-74](https://fourkitchens.atlassian.net/browse/FKVR-74)
**This PR introduces the following changes:**
- Makes modal hotspots _actually_ clickable with the mouse raycaster.
- Removes the fuse cursor from the desktop experience.
- Allows desktop users to close modals by clicking away from the modal.
- Adds support for the Daydream, Vive, and Oculus Rift controllers. (Only tested with Daydream, me no haz Vive or Rift yet).
- Improves consistency of modal interactions (Solves a rare bug that caused modals to sometimes open randomly).

## Steps to Test
- [x] Checkout this branch.
- [x] Run `yarn i` in this repo's root.
- [x] Run `yarn start` in this repo's root.
- [x] Open the app in your desktop browser.
- [x] Ensure you can open and close modals with hotspots/close button, and by clicking anywhere on the sky.
- [x] Ensure opening a modal closes other open modals.
- [ ] Open the app in Android Chrome over your local network.
- [ ] Note that you see a fuse cursor, and can use it to close/open modals via the hotspots.
- [ ] Enter VR mode.
- [ ] Insert your phone into the Daydream headset, initialize your controller, and ensure your Daydream controller loads into the scene. This might take a second, and also might require you to perform one click after initializing the controller, as the gamepad API is sometimes slow to call the event handlers that cause the controller to show up, and the fuse cursor to disappear.
- [ ] Note that you can activate hotspots by pointing to them and clicking on them with your Daydream controller.

## Note
I need to test the Cardboard (fuse-based interactions) with this update. I'm charging my iPad so I can do this in Safari, as Chrome for Android now integrates very tightly with Daydream, and won't let you load a WebVR app in Cardboard (even with NFC off). I need to look into this and figure it out, that's the only outstanding part of this ticket.
