### PR TITLE
Set initial camera rotation and position

### DIFF
--- a/src/components/Camera.jsx
+++ b/src/components/Camera.jsx
@@ -4,7 +4,7 @@
  */
 
 import { Entity } from 'aframe-react';
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 
 require('aframe-mouse-cursor-component');
 
@@ -64,6 +64,8 @@ class Camera extends Component {
         id="camera"
         mouse-cursor={!AFRAME.utils.device.checkHeadsetConnected()}
         camera
+        rotation={this.props.rotation}
+        position={this.props.position}
         look-controls {...this.state.props}
       >
         {cursor}
@@ -71,5 +73,19 @@ class Camera extends Component {
     );
   }
 }
+
+Camera.propTypes = {
+  rotation: PropTypes.string,
+  position: PropTypes.shape({
+    x: PropTypes.integer,
+    y: PropTypes.integer,
+    z: PropTypes.integer,
+  }),
+};
+
+Camera.defaultProps = {
+  rotation: '0 0 0',
+  position: { x: 0, y: 0, z: 0 },
+};
 
 export default Camera;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -36,6 +36,7 @@ class NavigationScene extends React.Component {
     this.state.scenes = [SuzyBackyard, SuzyOffice, MikeOffice, MikeWorkshop, NoMatch];
     this.state.initialScene = this.fetchSceneByName('mike-workshop');
     this.state.currentScene = this.fetchSceneByUrl();
+    this.state.currentScene.camera = this.state.currentScene.camera || {};
   }
 
   /**
@@ -121,7 +122,10 @@ class NavigationScene extends React.Component {
         <Entity laser-controls position={{ x: 0.3, y: -0.6, z: 0 }} />
         <Entity primative="a-assets">{this.fetchSkys()}</Entity>
         <Entity primitive="a-sky" radius="30" src={`#${this.state.currentScene.name}`} />
-        <Camera />
+        <Camera
+          rotation={this.state.currentScene.camera.rotation || '0 0 0'}
+          postition={this.state.currentScene.camera.position || { x: 0, y: 0, z: 0 }}
+        />
         {this.state.currentScene.scene()}
       </Scene>
     );


### PR DESCRIPTION
# Set initial camera rotation and position
**This PR introduces the following changes:**
- Handles properties for setting initial camera rotation and position in a scene.

## Steps to Test
- [ ] Checkout this branch.
- [ ] Run `yarn` or `npm i` in this repo's root.
- [ ] Run `npm run start` in this repo's root.
- [ ] Navigate to the IP address:port given to you in the start script output in Chrome on your phone, which should be connected to the same network as your computer. (And not using a VPN).
- [ ] Visit a scene and note the initial scene orientation (camera rotation).
- [ ] Edit the scene and add the camera property:
```
const scene1 = {
  name: 'scene1',
  sky: require('../../assets/images/scenes/scene1.jpg'),
  camera: {
    rotation: '0 180 0',
  },
  scene: () => (
...
```
- [ ] You should now be facing the opposite direction when the scene loads.