### PR TITLE
FKVR-147: Turn off autoplay for Mike's table saw audio.

### DIFF
--- a/src/components/scenes/Mike-workshop.jsx
+++ b/src/components/scenes/Mike-workshop.jsx
@@ -25,7 +25,6 @@ const MikeWorkshop = {
         src={`src: url(${require('../../assets/sounds/mike-saw.mp3')})`}
         position={{ x: 6.94, y: -7.98, z: -16.98 }}
         volume={10}
-        autoplay
       />
       <Entity
         rotation={{ x: 0, y: -26.76, z: 0 }}


### PR DESCRIPTION
# [FKVR-147](https://fourkitchens.atlassian.net/browse/FKVR-147)
**This PR introduces the following changes:**
- The audio for Mike's tablesaw will no longer autoplay on load. @toddross reports that this audio has alarmed users in his demo because it:
  - autoplays,
  - is loud,
  - the Daydream/Cardboard demo puts a user's phone (audio source) on his or her face,
  - the sound in question is a giant saw.

## Steps to Test
- [ ] Checkout this branch.
- [ ] Run `yarn` or `npm i` in this repo's root.
- [ ] Run `npm run start` in this repo's root.
- [ ] Navigate to the IP address:port given to you in the start script output in Chrome on your phone, which should be connected to the same network as your computer. (And not using a VPN).
- [ ] Load the demo. It will automatically start in the _Mike's Workshop_ scene. The scene will begin in silence; the saw can be played by looking at/interacting with the audio marker over the saw.